### PR TITLE
Update KS19.lua, add countries

### DIFF
--- a/Mods/tech/HighDigitSAMs/Database/Vehicle/KS19.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Vehicle/KS19.lua
@@ -59,3 +59,4 @@ GT.attribute = {wsType_Ground,wsType_SAM,wsType_Gun,ZU_23,
                 "Static AAA",
                 };
 GT.category = "Air Defence";
+GT.Countries = {"Bulgaria", "Czech Republic", "Germany", "Hungary", "Poland", "Romania", "USSR", "China", "Vietnam", "Iran", "Pakistan", "Russia"}


### PR DESCRIPTION
Adds Warsaw pact countries and Vietnam, Iran, Pakistan, and Russia as countries that use the KS-19.