### PR TITLE
Add Strela-2 and 2M to HDS

### DIFF
--- a/Mods/tech/HighDigitSAMs/Database/Vehicle/Strela-2.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Vehicle/Strela-2.lua
@@ -1,0 +1,53 @@
+-- Strela-2 Russia Manpad
+
+GT = {};
+GT_t.ws = 0;
+set_recursive_metatable(GT, GT_t.generic_human);
+set_recursive_metatable(GT.chassis, GT_t.CH_t.HUMAN);
+GT.animation = {};
+set_recursive_metatable(GT.animation, GT_t.CH_t.HUMAN_ANIMATION);
+
+GT.visual.shape = "soldier_ru_03";
+GT.visual.shape_dstr = "soldier_ru_03_d";
+
+GT.mobile = true;
+				
+GT.sensor = {};
+set_recursive_metatable(GT.sensor, GT_t.SN_visual);
+
+-- weapon systems
+
+GT.WS = {};
+GT.WS.maxTargetDetectionRange = 7500;
+GT.WS.fire_on_march = false;
+
+local ws = GT_t.inc_ws();
+GT.WS[ws] = {};
+set_recursive_metatable(GT.WS[ws], GT_t.WS_t.strela2_manpad);
+GT.WS[ws].cockpit = {"IglaSight/IglaSight", {0.0, 0.0, 0.0}}
+GT.WS[ws].pointer = "camera";
+local __LN = GT.WS[ws].LN[1]
+__LN.BR[1].connector_name = "POINT_LAUNCHER";
+__LN.sightMasterMode = 1;
+__LN.sightIndicationMode = 1;
+
+GT.Name = "SA-7 Strela-2 manpad";
+GT.DisplayName = _('MANPADS SA-7 Strela-2 "Grail"');
+GT.DisplayNameShort = _('SA-7');
+GT.Rate = 5;
+
+GT.DetectionRange  = GT.sensor.max_range_finding_target;
+GT.ThreatRange = GT.WS[1].LN[1].distanceMax;
+GT.mapclasskey = "P0091000202";
+
+GT.attribute = {wsType_Ground,wsType_SAM,wsType_Miss,IglaRUS_1,
+				"MANPADS",
+				"IR Guided SAM",
+				"New infantry",
+				};
+				
+GT.category = "Air Defence";
+GT.tags = { "Air Defence", "MANPADS" };
+GT.Transportable = {
+	size = 100
+}

--- a/Mods/tech/HighDigitSAMs/Database/Vehicle/Strela-2M.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Vehicle/Strela-2M.lua
@@ -1,0 +1,53 @@
+-- Strela-2M Russia Manpad
+
+GT = {};
+GT_t.ws = 0;
+set_recursive_metatable(GT, GT_t.generic_human);
+set_recursive_metatable(GT.chassis, GT_t.CH_t.HUMAN);
+GT.animation = {};
+set_recursive_metatable(GT.animation, GT_t.CH_t.HUMAN_ANIMATION);
+
+GT.visual.shape = "soldier_ru_03";
+GT.visual.shape_dstr = "soldier_ru_03_d";
+
+GT.mobile = true;
+				
+GT.sensor = {};
+set_recursive_metatable(GT.sensor, GT_t.SN_visual);
+
+-- weapon systems
+
+GT.WS = {};
+GT.WS.maxTargetDetectionRange = 7500;
+GT.WS.fire_on_march = false;
+
+local ws = GT_t.inc_ws();
+GT.WS[ws] = {};
+set_recursive_metatable(GT.WS[ws], GT_t.WS_t.strela2m_manpad);
+GT.WS[ws].cockpit = {"IglaSight/IglaSight", {0.0, 0.0, 0.0}}
+GT.WS[ws].pointer = "camera";
+local __LN = GT.WS[ws].LN[1]
+__LN.BR[1].connector_name = "POINT_LAUNCHER";
+__LN.sightMasterMode = 1;
+__LN.sightIndicationMode = 1;
+
+GT.Name = "SA-7b Strela-2M manpad";
+GT.DisplayName = _('MANPADS SA-7b Strela-2M "Grail"');
+GT.DisplayNameShort = _('SA-7b');
+GT.Rate = 5;
+
+GT.DetectionRange  = GT.sensor.max_range_finding_target;
+GT.ThreatRange = GT.WS[1].LN[1].distanceMax;
+GT.mapclasskey = "P0091000202";
+
+GT.attribute = {wsType_Ground,wsType_SAM,wsType_Miss,IglaRUS_1,
+				"MANPADS",
+				"IR Guided SAM",
+				"New infantry",
+				};
+				
+GT.category = "Air Defence";
+GT.tags = { "Air Defence", "MANPADS" };
+GT.Transportable = {
+	size = 100
+}

--- a/Mods/tech/HighDigitSAMs/Database/Weapon/9M32.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Weapon/9M32.lua
@@ -1,0 +1,254 @@
+-- Missile
+local function calcPiercingMass(warhead)
+	warhead.piercing_mass  = warhead.mass;
+	if (warhead.expl_mass/warhead.mass > 0.1) then
+		warhead.piercing_mass  = warhead.mass/5.0;
+	end
+end
+
+local function simple_aa_warhead(power, caliber) -- By Saint
+    local res = {};
+
+	res.caliber = caliber
+	res.mass = power; --old explosion damage effect
+    res.expl_mass = power;
+    res.other_factors = {1, 1, 1};
+    res.obj_factors = {1, 1};
+    res.concrete_factors = {1, 1, 1};
+    res.cumulative_factor = 0;
+    res.concrete_obj_factor = 0.0;
+    res.cumulative_thickness = 0.0;
+    
+	calcPiercingMass(res)
+    return res;
+end
+
+local SA9M32 = {
+	category		= CAT_MISSILES,
+	name			= "Strela-2",
+	user_name		= _("9M32 Strela-2"),
+	scheme			= "self_homing_spin_missile2",
+	class_name		= "wAmmunitionSelfHoming",
+	model			= "fim-92",
+	mass			= 9.2, --10.3
+	
+	wsTypeOfWeapon  = {wsType_Weapon,wsType_Missile,wsType_SA_Missile,WSTYPE_PLACEHOLDER};
+	
+	Escort = 0,
+	Head_Type = 1,
+	sigma = {6, 6, 6},
+	M = 9.2, --10.3
+	H_max = 1500.0, --3000.0
+	H_min = 1.0,
+	Diam = 72.0,
+	Cx_pil = 1,
+	D_max = 3200.0, --4500.0
+	D_min = 800.0, --500.0
+	Head_Form = 0, --1
+	Life_Time = 14.0,
+	Nr_max = 4,
+	v_min = 70.0, --70.0
+	v_mid = 480.0, --570.0
+	Mach_max = 1.6, --1.6
+	t_b = 0.0,
+	t_acc = 2.0,
+	t_marsh = 4.0,
+	Range_max = 3200.0, --4500.0
+	H_min_t = 10.0,
+	Fi_start = math.rad(1),
+	Fi_rak = 3.14152,
+	Fi_excort = 0.7,
+	Fi_search = 99.9,
+	OmViz_max = 99.9,
+	warhead = {
+		mass					= 1.15, --1.25
+		expl_mass				= 0.37, --1.25
+		caliber					= 72,
+		other_factors			= { 1.325, 1.325, 1.325 },
+		obj_factors				= { 1.325, 1.325 },
+		concrete_factors		= { 1.325, 1.325, 1.0 },
+		cumulative_factor		= 0.0,
+		concrete_obj_factor		= 0.0,    
+		cumulative_thickness	= 0.0,
+		piercing_mass 			= 0.23, --1.25
+		time_self_destruct		= 14,
+	},
+	warhead_air = {
+		mass					= 1.15, --1.25
+		expl_mass				= 0.37, --1.25
+		caliber					= 72,
+		other_factors			= { 1.325, 1.325, 1.325 },
+		obj_factors				= { 1.325, 1.325 },
+		concrete_factors		= { 1.325, 1.325, 1.0 },
+		cumulative_factor		= 0.0,
+		concrete_obj_factor		= 0.0,    
+		cumulative_thickness	= 0.0,
+		piercing_mass 			= 0.23, --1.25
+		time_self_destruct		= 14,
+	},
+	X_back = -0.781,
+	Y_back = 0.0,
+	Z_back = 0.0,
+	Reflection = 0.01,
+	KillDistance = 0.5,
+	--seeker sensivity params
+	SeekerSensivityDistance = 6000, -- original value 8000 The range of target with IR value = 1. In meters.
+	ccm_k0 = 1.5,  -- original value 1.0 | Counter Countermeasures Probability Factor. Value = 0 - missile has absolutely resistance to countermeasures. Default = 1 (medium probability)
+	SeekerCooled			= false, -- original value true | True is cooled seeker and false is not cooled seeker.
+	shape_table_data = 
+	{
+		{
+			name	 = "Strela-2";
+			file  	 = "fim-92";
+			life  	 = 1;
+			fire  	 = { 0, 1};
+			username = "SA9M32";
+			index = WSTYPE_PLACEHOLDER;
+		},
+	},
+	
+	controller = {
+		boost_start = 0.001,
+		march_start = 0.40,
+		march2_start = 2.0,
+	},
+	
+	booster = {
+		impulse								= 140,
+		fuel_mass							= 0.22,
+		work_time							= 0.048,
+		boost_time							= 0,
+		boost_factor						= 0,
+		nozzle_position						= {{-0.8, 0.0, 0}},
+		nozzle_orientationXYZ				= {{0.0, 0.0, 0.0}},
+		tail_width							= 0.4,
+		smoke_color							= {1.0, 1.0, 1.0},
+		smoke_transparency					= 0.9,
+		custom_smoke_dissipation_factor		= 0.3,				
+	},
+		
+	march = {
+		impulse								= 200,
+		fuel_mass							= 2.1,
+		work_time							= 1.9,
+		boost_time							= 0,
+		boost_factor						= 0,
+		nozzle_position						= {{-0.8, 0.0, 0.0}},
+		nozzle_orientationXYZ				= {{0.0, 0.0, 0.0}},
+		tail_width							= 0.2,
+		smoke_color							= {1.0, 1.0, 1.0},
+		smoke_transparency					= 0.9,
+		custom_smoke_dissipation_factor		= 0.3,	
+	},
+	
+	march2 = {
+		impulse								= 180,
+		fuel_mass							= 1.6,
+		work_time							= 4.6,
+		boost_time							= 0,
+		boost_factor						= 0,
+		nozzle_position						= {{-0.8, 0.0, 0.0}},
+		nozzle_orientationXYZ				= {{0.0, 0.0, 0.0}},
+		tail_width							= 0.2,
+		smoke_color							= {1.0, 1.0, 1.0},
+		smoke_transparency					= 0.7,
+		custom_smoke_dissipation_factor		= 0.3,	
+	},
+
+	fm = {
+		mass        = 9.2, --10.3  
+		caliber     = 0.072,  
+		cx_coeff    = {1,1.15,0.8,0.4,1.5},
+		L           = 1.42, --1.52 lenght_m
+		I           = 1 / 12 * 9.2 * 1.42 * 1.42, -- 1 / 12 * 10.6 * 1.52 * 1.52 moment of inertia for a rod shaped object I = 1/12*Mass_kg*Lenght_m^2; 
+		Ma          = 0.6,
+		Mw          = 1.2,
+		Sw			= 0.2,
+		dCydA		= {0.07, 0.036},
+		A			= 0.6,
+		maxAoa		= 0.3,
+		finsTau		= 0.1,
+		freq		= 20,
+	},
+	
+	simple_IR_seeker = {
+		sensitivity		= 6000, --8000
+		cooled			= false, --true
+		delay			= 0.0,
+		GimbLim			= math.rad(40),--30
+		FOV				= math.rad(1.5);--2
+		opTime			= 11.0, --14
+		target_H_min	= 0.0,
+		flag_dist		= 150.0,
+		abs_err_val		= 3,
+		ground_err_k	= 3,
+		ccm_k0 			= 1.5, --1.0
+	},
+	
+	simple_gyrostab_seeker = {
+		gimbal_lim = math.rad(40)
+		omega_max	= math.rad(8)
+	},
+	
+	--Replaced proximity with impact fuze, borrowed from FIM-92
+	
+	fuze = {
+		default_self_destruct_delay	= 14,
+		fuze_time_sigma				= 0.9
+	},
+	
+	--fuze_proximity = {
+	--	ignore_inp_armed	= 1,
+	--	radius				= 1,
+	--},
+	
+	autopilot = {
+		K				= 1.4,
+		Kg				= 0.2,
+		Ki				= 0.0,
+		finsLimit		= 0.05,
+		delay			= 0.5,
+		fin2_coeff		= 0.5,
+	},
+};
+declare_weapon(SA9M32)
+
+GT_t.LN_t.strela2 = {}
+GT_t.LN_t.strela2.type = 4
+GT_t.LN_t.strela2.distanceMin = 800 --500
+GT_t.LN_t.strela2.distanceMax = 3200 --4500
+GT_t.LN_t.strela2.reactionTime = 2;
+GT_t.LN_t.strela2.launch_delay = 1;
+GT_t.LN_t.strela2.maxShootingSpeed = 0
+GT_t.LN_t.strela2.reflection_limit = 0.22
+GT_t.LN_t.strela2.ECM_K = -1
+GT_t.LN_t.strela2.min_launch_angle = math.rad(-20);
+GT_t.LN_t.strela2.inclination_correction_upper_limit = math.rad(0);
+GT_t.LN_t.strela2.inclination_correction_bias = (0);
+GT_t.LN_t.strela2.sensor = {}
+set_recursive_metatable(GT_t.LN_t.strela2.sensor, GT_t.WSN_t[0])
+GT_t.LN_t.strela2.PL = {}
+GT_t.LN_t.strela2.PL[1] = {}
+GT_t.LN_t.strela2.PL[1].ammo_capacity = 3
+GT_t.LN_t.strela2.PL[1].shot_delay = 0.01
+GT_t.LN_t.strela2.PL[1].reload_time = 120
+GT_t.LN_t.strela2.PL[1].type_ammunition = SA9M32.wsTypeOfWeapon;
+GT_t.LN_t.strela2.PL[1].automaticLoader = false
+GT_t.LN_t.strela2.BR = { { pos = {1, 0, 0}, drawArgument = 4}, }
+
+GT_t.WS_t.strela2_manpad = {};
+GT_t.WS_t.strela2_manpad.pos = {-0.071, 1.623,0};
+GT_t.WS_t.strela2_manpad.angles = {
+					{math.rad(180), math.rad(-180), math.rad(-45), math.rad(80)},
+					};
+GT_t.WS_t.strela2_manpad.drawArgument1 = 0;
+GT_t.WS_t.strela2_manpad.drawArgument2 = 1;
+GT_t.WS_t.strela2_manpad.omegaY = 1.5;
+GT_t.WS_t.strela2_manpad.omegaZ = 1.5;
+GT_t.WS_t.strela2_manpad.pidY = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2_manpad.pidZ = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2_manpad.reloadAngleY = -100; -- not constrained
+GT_t.WS_t.strela2_manpad.LN = {};
+GT_t.WS_t.strela2_manpad.LN[1] = {};
+set_recursive_metatable(GT_t.WS_t.strela2_manpad.LN[1], GT_t.LN_t.strela2);
+GT_t.WS_t.strela2_manpad.LN[1].PL[1].shot_delay = 13;

--- a/Mods/tech/HighDigitSAMs/Database/Weapon/9M32M.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Weapon/9M32M.lua
@@ -1,0 +1,254 @@
+-- Missile
+local function calcPiercingMass(warhead)
+	warhead.piercing_mass  = warhead.mass;
+	if (warhead.expl_mass/warhead.mass > 0.1) then
+		warhead.piercing_mass  = warhead.mass/5.0;
+	end
+end
+
+local function simple_aa_warhead(power, caliber) -- By Saint
+    local res = {};
+
+	res.caliber = caliber
+	res.mass = power; --old explosion damage effect
+    res.expl_mass = power;
+    res.other_factors = {1, 1, 1};
+    res.obj_factors = {1, 1};
+    res.concrete_factors = {1, 1, 1};
+    res.cumulative_factor = 0;
+    res.concrete_obj_factor = 0.0;
+    res.cumulative_thickness = 0.0;
+    
+	calcPiercingMass(res)
+    return res;
+end
+
+local SA9M32M = {
+	category		= CAT_MISSILES,
+	name			= "Strela-2M",
+	user_name		= _("9M32M Strela-2M"),
+	scheme			= "self_homing_spin_missile2",
+	class_name		= "wAmmunitionSelfHoming",
+	model			= "fim-92",
+	mass			= 9.85, --10.3
+	
+	wsTypeOfWeapon  = {wsType_Weapon,wsType_Missile,wsType_SA_Missile,WSTYPE_PLACEHOLDER};
+	
+	Escort = 0,
+	Head_Type = 1,
+	sigma = {6, 6, 6},
+	M = 9.85, --10.3
+	H_max = 2300.0, --3000.0
+	H_min = 1.0,
+	Diam = 72.0,
+	Cx_pil = 1,
+	D_max = 4200.0, --4500.0
+	D_min = 800.0, --500.0
+	Head_Form = 0, --1
+	Life_Time = 17.0,
+	Nr_max = 4,
+	v_min = 70.0, --70.0
+	v_mid = 500.0, --570.0
+	Mach_max = 1.6, --1.6
+	t_b = 0.0,
+	t_acc = 2.0,
+	t_marsh = 4.0,
+	Range_max = 4200.0, --4500.0
+	H_min_t = 10.0,
+	Fi_start = math.rad(1),
+	Fi_rak = 3.14152,
+	Fi_excort = 0.7,
+	Fi_search = 99.9,
+	OmViz_max = 99.9,
+	warhead = {
+		mass					= 1.8, --1.25
+		expl_mass				= 0.37, --1.25
+		caliber					= 72,
+		other_factors			= { 1.325, 1.325, 1.325 },
+		obj_factors				= { 1.325, 1.325 },
+		concrete_factors		= { 1.325, 1.325, 1.0 },
+		cumulative_factor		= 0.0,
+		concrete_obj_factor		= 0.0,    
+		cumulative_thickness	= 0.0,
+		piercing_mass 			= 0.36, --1.25
+		time_self_destruct		= 17,
+	},
+	warhead_air = {
+		mass					= 1.8, --1.25
+		expl_mass				= 0.37, --1.25
+		caliber					= 72,
+		other_factors			= { 1.325, 1.325, 1.325 },
+		obj_factors				= { 1.325, 1.325 },
+		concrete_factors		= { 1.325, 1.325, 1.0 },
+		cumulative_factor		= 0.0,
+		concrete_obj_factor		= 0.0,    
+		cumulative_thickness	= 0.0,
+		piercing_mass 			= 0.36, --1.25
+		time_self_destruct		= 17,
+	},
+	X_back = -0.781,
+	Y_back = 0.0,
+	Z_back = 0.0,
+	Reflection = 0.01,
+	KillDistance = 0.5,
+	--seeker sensivity params
+	SeekerSensivityDistance = 6000, -- original value 8000 The range of target with IR value = 1. In meters.
+	ccm_k0 = 1.4,  -- original value 1.0 | Counter Countermeasures Probability Factor. Value = 0 - missile has absolutely resistance to countermeasures. Default = 1 (medium probability)
+	SeekerCooled			= false, -- original value true | True is cooled seeker and false is not cooled seeker.
+	shape_table_data = 
+	{
+		{
+			name	 = "Strela-2M";
+			file  	 = "fim-92";
+			life  	 = 1;
+			fire  	 = { 0, 1};
+			username = "SA9M32M";
+			index = WSTYPE_PLACEHOLDER;
+		},
+	},
+	
+	controller = {
+		boost_start = 0.001,
+		march_start = 0.40,
+		march2_start = 2.0,
+	},
+	
+	booster = {
+		impulse								= 170,
+		fuel_mass							= 0.22,
+		work_time							= 0.048,
+		boost_time							= 0,
+		boost_factor						= 0,
+		nozzle_position						= {{-0.8, 0.0, 0}},
+		nozzle_orientationXYZ				= {{0.0, 0.0, 0.0}},
+		tail_width							= 0.4,
+		smoke_color							= {1.0, 1.0, 1.0},
+		smoke_transparency					= 0.9,
+		custom_smoke_dissipation_factor		= 0.3,				
+	},
+		
+	march = {
+		impulse								= 200,
+		fuel_mass							= 2.1,
+		work_time							= 1.9,
+		boost_time							= 0,
+		boost_factor						= 0,
+		nozzle_position						= {{-0.8, 0.0, 0.0}},
+		nozzle_orientationXYZ				= {{0.0, 0.0, 0.0}},
+		tail_width							= 0.2,
+		smoke_color							= {1.0, 1.0, 1.0},
+		smoke_transparency					= 0.9,
+		custom_smoke_dissipation_factor		= 0.3,	
+	},
+	
+	march2 = {
+		impulse								= 180,
+		fuel_mass							= 1.6,
+		work_time							= 4.6,
+		boost_time							= 0,
+		boost_factor						= 0,
+		nozzle_position						= {{-0.8, 0.0, 0.0}},
+		nozzle_orientationXYZ				= {{0.0, 0.0, 0.0}},
+		tail_width							= 0.2,
+		smoke_color							= {1.0, 1.0, 1.0},
+		smoke_transparency					= 0.7,
+		custom_smoke_dissipation_factor		= 0.3,	
+	},
+
+	fm = {
+		mass        = 9.85, --10.3  
+		caliber     = 0.072,  
+		cx_coeff    = {1,1.15,0.8,0.4,1.5},
+		L           = 1.44, --1.52 lenght_m
+		I           = 1 / 12 * 9.85 * 1.44 * 1.44, -- 1 / 12 * 10.6 * 1.52 * 1.52 moment of inertia for a rod shaped object I = 1/12*Mass_kg*Lenght_m^2; 
+		Ma          = 0.6,
+		Mw          = 1.2,
+		Sw			= 0.2,
+		dCydA		= {0.07, 0.036},
+		A			= 0.6,
+		maxAoa		= 0.3,
+		finsTau		= 0.1,
+		freq		= 20,
+	},
+	
+	simple_IR_seeker = {
+		sensitivity		= 6000, --8000
+		cooled			= false, --true
+		delay			= 0.0,
+		GimbLim			= math.rad(40),--30
+		FOV				= math.rad(1.9);--2
+		opTime			= 12.0, --14
+		target_H_min	= 0.0,
+		flag_dist		= 150.0,
+		abs_err_val		= 3,
+		ground_err_k	= 3,
+		ccm_k0 			= 1.4, --1.0
+	},
+	
+	simple_gyrostab_seeker = {
+		gimbal_lim = math.rad(40)
+		omega_max	= math.rad(8)
+	},
+	
+	--Replaced proximity with impact fuze, borrowed from FIM-92
+	
+	fuze = {
+		default_self_destruct_delay	= 17,
+		fuze_time_sigma				= 0.9
+	},
+	
+	--fuze_proximity = {
+	--	ignore_inp_armed	= 1,
+	--	radius				= 1,
+	--},
+	
+	autopilot = {
+		K				= 1.4,
+		Kg				= 0.2,
+		Ki				= 0.0,
+		finsLimit		= 0.05,
+		delay			= 0.5,
+		fin2_coeff		= 0.5,
+	},
+};
+declare_weapon(SA9M32M)
+
+GT_t.LN_t.strela2m = {}
+GT_t.LN_t.strela2m.type = 4
+GT_t.LN_t.strela2m.distanceMin = 800 --500
+GT_t.LN_t.strela2m.distanceMax = 4200 --4500
+GT_t.LN_t.strela2m.reactionTime = 2;
+GT_t.LN_t.strela2m.launch_delay = 1;
+GT_t.LN_t.strela2m.maxShootingSpeed = 0
+GT_t.LN_t.strela2m.reflection_limit = 0.22
+GT_t.LN_t.strela2m.ECM_K = -1
+GT_t.LN_t.strela2m.min_launch_angle = math.rad(-20);
+GT_t.LN_t.strela2m.inclination_correction_upper_limit = math.rad(0);
+GT_t.LN_t.strela2m.inclination_correction_bias = (0);
+GT_t.LN_t.strela2m.sensor = {}
+set_recursive_metatable(GT_t.LN_t.strela2m.sensor, GT_t.WSN_t[0])
+GT_t.LN_t.strela2m.PL = {}
+GT_t.LN_t.strela2m.PL[1] = {}
+GT_t.LN_t.strela2m.PL[1].ammo_capacity = 3
+GT_t.LN_t.strela2m.PL[1].shot_delay = 0.01
+GT_t.LN_t.strela2m.PL[1].reload_time = 120
+GT_t.LN_t.strela2m.PL[1].type_ammunition = SA9M32M.wsTypeOfWeapon;
+GT_t.LN_t.strela2m.PL[1].automaticLoader = false
+GT_t.LN_t.strela2m.BR = { { pos = {1, 0, 0}, drawArgument = 4}, }
+
+GT_t.WS_t.strela2m_manpad = {};
+GT_t.WS_t.strela2m_manpad.pos = {-0.071, 1.623,0};
+GT_t.WS_t.strela2m_manpad.angles = {
+					{math.rad(180), math.rad(-180), math.rad(-45), math.rad(80)},
+					};
+GT_t.WS_t.strela2m_manpad.drawArgument1 = 0;
+GT_t.WS_t.strela2m_manpad.drawArgument2 = 1;
+GT_t.WS_t.strela2m_manpad.omegaY = 1.5;
+GT_t.WS_t.strela2m_manpad.omegaZ = 1.5;
+GT_t.WS_t.strela2m_manpad.pidY = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2m_manpad.pidZ = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2m_manpad.reloadAngleY = -100; -- not constrained
+GT_t.WS_t.strela2m_manpad.LN = {};
+GT_t.WS_t.strela2m_manpad.LN[1] = {};
+set_recursive_metatable(GT_t.WS_t.strela2m_manpad.LN[1], GT_t.LN_t.strela2m);
+GT_t.WS_t.strela2m_manpad.LN[1].PL[1].shot_delay = 13;

--- a/Mods/tech/HighDigitSAMs/entry.lua
+++ b/Mods/tech/HighDigitSAMs/entry.lua
@@ -68,6 +68,8 @@ weapon_file("/Database/Weapon/9M82.lua")
 weapon_file("/Database/Weapon/9M83.lua")
 weapon_file("/Database/Weapon/9M342.lua")
 weapon_file("/Database/Weapon/9M36.lua")
+weapon_file("/Database/Weapon/9M32.lua")
+weapon_file("/Database/Weapon/9M32M.lua")
 
 --S-300PMU1
 
@@ -118,6 +120,8 @@ vehicle_file("/Database/Vehicle/5P73 V-601P LN.lua")
 
 vehicle_file("/Database/Vehicle/iglaS.lua")
 vehicle_file("/Database/Vehicle/Strela-3.lua")
+vehicle_file("/Database/Vehicle/Strela-2.lua")
+vehicle_file("/Database/Vehicle/Strela-2M.lua")
 
 -- Misc units
 


### PR DESCRIPTION
Strela-2 and 2M were created by cloning the Strela-3 entry and tweaking speeds, ranges, seeker parameters, masses, ccm, physical dimensions, warhead yield, etc. to match researched properties of the 9M32/M systems.

Limited testing shows capability close to that expected by reading after-action testimony and reports from early 70s: 

- strela-2 loves flares
- able to hit gently maneuvering, low flying jets that aren't dropping flares
- contact fuze works as expected
- low damage output, based on the 0.37 kg of explosive in the warhead makes hits mostly survivable with severed hyd/fuel lines or engine failures

ToDos:

1. lock-on aspect limitation for the 9M32: rear only
2. lock-on aspect limitation for the 9M32M: rear and rudimentary side
3. motors: booster, march, march - verify impulse, propellant mass, use of t_acc / t_marsh against this section
4. check if sensor / missile capability expressed in angular tracking speed is implemented (other than by Nr_max) and how; apply researched values
5. explore warhead yield calculations: why calculate piercing_mass if for all ED weapons piercing_mass = mass * 0.2
6. warhead yield through other_factors: does this parameter affect explosion size in the air? ED documentation points to ground effect only