### PR TITLE
Add HARM Code for the S-300VM TR

### DIFF
--- a/Mods/tech/HighDigitSAMs/Database/Vehicle/radar/9S15M2 S-300VM SR.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Vehicle/radar/9S15M2 S-300VM SR.lua
@@ -68,7 +68,8 @@ GT.Sensors = { RADAR = GT.Name };
 GT.DetectionRange  = GT.sensor.max_range_finding_target;
 GT.ThreatRange = 0;
 GT.mapclasskey = "P0091000083";
-GT.attribute = {wsType_Ground,wsType_SAM,wsType_Radar,RLO_9C15MT,
+GT.attribute = {wsType_Ground,wsType_SAM,wsType_Radar,
+                RLO_9C15MT, -- RLO 9C15MT, RWR: BD, HARM Code: 106
 				"LR SAM",
 				"SAM SR",
 				"RADAR_BAND1_FOR_ARM",

--- a/Mods/tech/HighDigitSAMs/Database/Vehicle/radar/9S19M2 S-300VM SR.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Vehicle/radar/9S19M2 S-300VM SR.lua
@@ -68,7 +68,8 @@ GT.Sensors = { RADAR = GT.Name };
 GT.DetectionRange  = GT.sensor.max_range_finding_target;
 GT.ThreatRange = 0;
 GT.mapclasskey = "P0091000083";
-GT.attribute = {wsType_Ground,wsType_SAM,wsType_Radar,RLO_9C19M2,
+GT.attribute = {wsType_Ground,wsType_SAM,wsType_Radar,
+                RLO_9C19M2, -- RLO 9C19M2, RWR: HS, HARM Code: 106
 				"LR SAM",
 				"SAM SR",
 				"RADAR_BAND1_FOR_ARM",

--- a/Mods/tech/HighDigitSAMs/Database/Vehicle/radar/9S32ME S-300VM TR.lua
+++ b/Mods/tech/HighDigitSAMs/Database/Vehicle/radar/9S32ME S-300VM TR.lua
@@ -90,6 +90,7 @@ GT.DetectionRange  = GT.sensor.max_range_finding_target;
 GT.ThreatRange = 0;
 GT.mapclasskey = "P0091000083";
 GT.attribute = {wsType_Ground,wsType_SAM,wsType_Radar,
+				RLS_9C32_1, -- RLS 9C32 1, RWR: 12, HARM Code: 112
 				"LR SAM",
 				"SAM TR",
 				"RADAR_BAND1_FOR_ARM",


### PR DESCRIPTION
Added the RLS_9C32_1 attribute to the S-300VM TR. This allows it to be targeted by the HARM, and show up as a known radar in RWRs. HARM Code **112**, RWR Symbol: **12** . The current RLS_9C32_1  does not appear to be used by any major unit available in the datamine.